### PR TITLE
Fix Examples point 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Find below some patterns to help you write modules:
 5. [interface-first](patterns/pretend-modules/InterfaceFirst.re)
 6. [pretend_modules](patterns/pretend-modules/PretendModules.re)
 7. [interface-first](patterns/pretend-modules/InterfaceFirst.re)
-8. [one-module-one-thing](patterns/100-named-args-functions/PretendModules.re)
+8. [one-module-one-thing](patterns/one-module-one-thing/OneModuleOneThing.re)
 9. [100-named-args-functions](patterns/100-named-args-functions/HundredNamedArgsFunctions.re)
 10. [private-types](patterns/private-types/PrivateTypes.re)
 11. [Interpreter Pattern](patterns/interpreter/free_monad_interpreter.re)


### PR DESCRIPTION
Number 8 in examples list have wrong link. It redirects to 404.
I think it should redirect to /one-module-one-thing/OneModuleOneThing.re